### PR TITLE
fix: use set -euo pipefail in tests/format.sh (#3)

### DIFF
--- a/tests/format.sh
+++ b/tests/format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # In-place formatters. Run inside `nix develop` so every tool is on PATH.
-set -uo pipefail
+set -euo pipefail
 
 ROOT="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
 cd "$ROOT" || exit 1


### PR DESCRIPTION
Closes #3

## What changed

Changed `set -uo pipefail` to `set -euo pipefail` on line 3 of `tests/format.sh`. The missing `-e` flag meant any formatter (`shfmt`, `nixpkgs-fmt`, `taplo`) could fail silently — the script would continue running and exit 0 regardless. With `-e` added, the script now exits immediately as soon as any command fails, matching the behavior of `install.sh`.

## Why

A broken formatter invocation (e.g. `nixpkgs-fmt` erroring on a malformed `.nix` file) was silently swallowed, leaving callers with no signal that formatting failed and potentially leaving files in an inconsistent state.

## Test / build result

- `bash -n tests/format.sh` — PASS
- `shellcheck tests/format.sh` — PASS
- `tests/check.sh` shell section — PASS (Nix checks fail due to `nix-instantiate` not being installed in this environment, which is a pre-existing unrelated issue)

🤖 AI-generated — review before merging.