### PR TITLE
ci: add dedicated format-check job (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,21 @@ jobs:
 
       - name: Run check.sh inside dev shell
         run: nix develop --command bash tests/check.sh
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Verify formatting inside dev shell
+        run: |
+          nix develop --command bash -euo pipefail -c '
+            shfmt -d -i 4 -ci install.sh wallpapers/generate.sh tests/check.sh tests/format.sh
+            nixpkgs-fmt --check $(find . -name "*.nix" -not -path "./.git/*" -not -path "./nixos/hardware-configuration.nix")
+            taplo format --check starship/starship.toml
+          '


### PR DESCRIPTION
Closes #4

## What changed and why

Added a dedicated `format` job to `.github/workflows/ci.yml` that runs inside `nix develop` and explicitly invokes the three format checkers:

- `shfmt -d -i 4 -ci` — checks shell script formatting
- `nixpkgs-fmt --check` — checks Nix file formatting
- `taplo format --check` — checks TOML formatting

The existing `check` job (which runs `tests/check.sh`) already included these checks bundled alongside lint and syntax checks, but there was no dedicated CI status check specifically for formatting. This new job makes format verification a first-class, named CI check so that formatting failures are immediately visible as a separate status in pull requests rather than buried inside the combined lint output.

The format commands exactly match the file lists and flags used in `tests/format.sh` / `tests/check.sh`, so the CI gate and the local fix script stay in sync.

## Test / build result

YAML validated locally. No toolchain available to run the full `nix develop` environment in this environment, but the workflow is structurally identical to the existing `check` job (same `install-nix-action`, same `nix develop --command` pattern). The current `main` branch already has all files properly formatted (per `tests/check.sh` which runs the same checks), so the new job should pass on `main`.

🤖 AI-generated — review before merging.