### PR TITLE
docs: replace <user> placeholder with named configs in macOS section (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,29 @@ rebuild, then delete `~/dotfiles`.
 
 ### Apply
 
+Available configurations: `ibuki` (personal MacBook) and `yoshida` (work MacBook).
+Replace `<username>` below with whichever matches your machine's login name.
+
 ```bash
 # Enable flakes if you haven't:
 mkdir -p ~/.config/nix
 echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
 
 # First run: bootstraps darwin-rebuild, then applies system + user.
-sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake ~/dotfiles#<user>
+# Use ibuki or yoshida in place of <username>.
+sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake ~/dotfiles#<username>
 ```
 
 After the first run, re-apply with (aliased to `rebuild`):
 
 ```bash
-sudo darwin-rebuild switch --flake ~/dotfiles#<user>
+sudo darwin-rebuild switch --flake ~/dotfiles#<username>
 ```
 
 User-only changes (no sudo):
 
 ```bash
-home-manager switch --flake ~/dotfiles#<user>@mac    # aliased to `rebuild-home`
+home-manager switch --flake ~/dotfiles#<username>@mac    # aliased to `rebuild-home`
 ```
 
 ### Remove


### PR DESCRIPTION
Closes #5

## What changed and why

The macOS section of README.md used bare `<user>` placeholders in all three `darwin-rebuild` / `home-manager` commands without explaining what values are valid. Readers copying those commands verbatim would get a cryptic flake attribute error.

This PR:
- Adds a one-line header listing the two available configurations — `ibuki` (personal MacBook) and `yoshida` (work MacBook) — at the top of the Apply section, so a reader immediately knows what to substitute.
- Adds an inline comment (`# Use ibuki or yoshida in place of <username>.`) on the bootstrap command where confusion most often occurs.
- Renames the placeholder from `<user>` to `<username>` to be slightly more self-describing and consistent across all three occurrences.

## Test / build result

This repo has no build or test toolchain (pure dotfiles / Nix config). The change is documentation-only; no code was altered.

🤖 AI-generated — review before merging.