### PR TITLE
ci: cache Nix store to speed up CI (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   check:
@@ -17,6 +18,12 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          save-always: true
 
       - name: Run check.sh inside dev shell
         run: nix develop --command bash tests/check.sh


### PR DESCRIPTION
Closes #6

## What changed and why

Added `nix-community/cache-nix-action@v6` to `.github/workflows/ci.yml`, keyed on `flake.lock`. This caches the Nix store between CI runs so that dependencies are only re-fetched when `flake.lock` changes.

Changes:
- Added `actions: write` to top-level workflow permissions (required for cache writes)
- Added `nix-community/cache-nix-action@v6` step after `cachix/install-nix-action`, with:
  - `primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}` — cache is busted whenever `flake.lock` changes
  - `restore-prefixes-first-match: nix-${{ runner.os }}-` — allows restoring the closest available cache on a cache miss (e.g. after a `flake.lock` bump, reuses the previous store as a warm base)
  - `save-always: true` — saves the cache even if a later step fails, so partial downloads aren't wasted

## Test / build result

This is a YAML-only change to the CI configuration itself; no project build or test suite applies locally. The change follows exactly the approach recommended in the issue and is consistent with the `nix-community/cache-nix-action` v6 documentation.

🤖 AI-generated — review before merging.