### PR TITLE
add macOS bootstrap script install-darwin.sh (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,20 @@ rebuild, then delete `~/dotfiles`.
 ### Apply
 
 ```bash
-# Enable flakes if you haven't:
-mkdir -p ~/.config/nix
-echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
-
-# First run: bootstraps darwin-rebuild, then applies system + user.
-sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake ~/dotfiles#<user>
+cd ~/dotfiles
+./install-darwin.sh   # enables flakes, confirms, runs darwin-rebuild
 ```
 
 After the first run, re-apply with (aliased to `rebuild`):
 
 ```bash
-sudo darwin-rebuild switch --flake ~/dotfiles#<user>
+sudo darwin-rebuild switch --flake ~/dotfiles#"$USER"
 ```
 
 User-only changes (no sudo):
 
 ```bash
-home-manager switch --flake ~/dotfiles#<user>@mac    # aliased to `rebuild-home`
+home-manager switch --flake ~/dotfiles#"$USER"@mac    # aliased to `rebuild-home`
 ```
 
 ### Remove

--- a/install-darwin.sh
+++ b/install-darwin.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Bootstrap a fresh macOS install onto this rice (nix-darwin + home-manager).
+#
+# Assumes:
+#   - This repo is checked out at ~/dotfiles (path is referenced by HM).
+#   - You are running on macOS (Apple Silicon or Intel).
+#
+# After the first switch, day-to-day rebuilds are just:
+#   sudo darwin-rebuild switch --flake ~/dotfiles#"$USER"
+
+set -euo pipefail
+DOTS="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+
+# 1. Verify Nix is available.
+if ! command -v nix >/dev/null 2>&1; then
+    echo "Nix is not installed. Install it first:"
+    echo "  https://nixos.org/download/#nix-install-macos"
+    exit 1
+fi
+
+# 2. Enable flakes if not already set.
+NIX_CONF="${XDG_CONFIG_HOME:-$HOME/.config}/nix/nix.conf"
+if ! grep -qF 'experimental-features' "$NIX_CONF" 2>/dev/null; then
+    echo "Enabling flakes in $NIX_CONF ..."
+    mkdir -p "$(dirname "$NIX_CONF")"
+    echo 'experimental-features = nix-command flakes' >> "$NIX_CONF"
+fi
+
+# 3. Confirm before running the first (slow) rebuild.
+echo
+echo "Will run:"
+echo "  sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake $DOTS#$USER"
+echo
+read -r -p "Proceed? [y/N] " ans
+case "${ans,,}" in
+    y | yes)
+        sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake "$DOTS#$USER"
+        ;;
+    *)
+        echo "Skipped. Run when ready:"
+        echo "  sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake $DOTS#$USER"
+        exit 0
+        ;;
+esac
+
+# 4. Print rebuild hint for subsequent runs.
+echo
+echo "Done. For subsequent rebuilds:"
+echo "  sudo darwin-rebuild switch --flake $DOTS#$USER          # full system"
+echo "  home-manager switch --flake $DOTS#${USER}@mac           # user-only (no sudo)"

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -54,7 +54,7 @@ run() {
 
 # ───── Shell ─────
 section "Shell"
-shell_files=(install.sh wallpapers/generate.sh tests/check.sh tests/format.sh)
+shell_files=(install.sh install-darwin.sh wallpapers/generate.sh tests/check.sh tests/format.sh)
 
 for f in "${shell_files[@]}"; do
     run "bash -n  $f" bash -n "$f"


### PR DESCRIPTION
Closes #7

## What changed

- **`install-darwin.sh`** (new): mirrors the structure of `install.sh` for macOS (nix-darwin). It:
  1. Verifies Nix is installed; if not, prints the official installer URL and exits.
  2. Enables flakes in `~/.config/nix/nix.conf` if the `experimental-features` line isn't already present.
  3. Shows the exact command that will run and prompts for confirmation before executing:
     ```
     sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake ~/dotfiles#"$USER"
     ```
  4. Prints the correct commands for subsequent rebuilds (full system and user-only).

- **`tests/check.sh`**: added `install-darwin.sh` to the `shell_files` array so it is covered by `bash -n`, `shellcheck`, and `shfmt` in CI.

- **`README.md`**: replaced the multi-step manual macOS `Apply` block with a single `./install-darwin.sh` call; replaced `~/dotfiles#<user>` placeholders with `~/dotfiles#"$USER"`.

## Test / build result

- `bash -n install-darwin.sh` — ✓ passes
- `bash -n tests/check.sh` — ✓ passes
- `shellcheck install-darwin.sh` — ✓ passes (no warnings)

No pre-existing failures found in the CI-relevant shell files.

🤖 AI-generated — review before merging.