### PR TITLE
feat: add Hyprland config syntax validation to check.sh (#8)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,16 +106,20 @@
         let pkgs = nixpkgs.legacyPackages.${system};
         in {
           default = pkgs.mkShell {
-            packages = with pkgs; [
-              shellcheck
-              shfmt
-              nixpkgs-fmt
-              statix
-              deadnix
-              lua
-              taplo
-              jq
-            ];
+            packages = with pkgs;
+              [
+                shellcheck
+                shfmt
+                nixpkgs-fmt
+                statix
+                deadnix
+                lua
+                taplo
+                jq
+              ]
+              # hyprland (provides hyprland + hyprctl) is Linux-only; it is
+              # used by tests/check.sh to validate the hypr/ config files.
+              ++ lib.optionals stdenv.isLinux [ hyprland ];
           };
         });
 

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -138,6 +138,44 @@ else
     skip "jq"
 fi
 
+# ───── Hyprland ─────
+section "Hyprland"
+hypr_files=(hypr/hyprland.conf hypr/hyprlock.conf hypr/hypridle.conf hypr/hyprpaper.conf)
+
+if have hyprland; then
+    # No live compositor needed: run with the headless wlr-backend so the
+    # display is never opened.  Hyprland parses the config file before
+    # touching any display, so config parse errors appear in the output
+    # regardless of backend success.  A timeout exit (rc 124) means the
+    # compositor started cleanly past config-parsing → the config is valid.
+    for f in "${hypr_files[@]}"; do
+        _rtdir=$(mktemp -d)
+        _hypr_rc=0
+        _hypr_out=$(XDG_RUNTIME_DIR="$_rtdir" \
+            WLR_BACKENDS=headless WLR_RENDERER=pixman \
+            timeout 5 hyprland --config "$ROOT/$f" 2>&1) || _hypr_rc=$?
+        rm -rf "$_rtdir"
+        if [ "$_hypr_rc" -eq 124 ]; then
+            ok "hyprland --config $f"
+        elif printf '%s\n' "$_hypr_out" | grep -qiE \
+            '\[Config\].*[Ee]rror|Unknown (variable|category|keyword)|[Pp]arse [Ee]rror'; then
+            bad "hyprland --config $f"
+            printf '%s\n' "$_hypr_out" | sed 's/^/      /'
+        else
+            ok "hyprland --config $f"
+        fi
+    done
+elif have hyprctl && [ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]; then
+    # Inside a live Hyprland session: ask the compositor to reload each file
+    # and check the response for error messages.
+    for f in "${hypr_files[@]}"; do
+        run "hyprctl configreload $f" \
+            bash -c "! hyprctl --config-path '$ROOT/$f' configreload 2>&1 | grep -qi error"
+    done
+else
+    skip "hyprctl / hyprland"
+fi
+
 echo
 if [ "${#skipped[@]}" -gt 0 ]; then
     printf "%sskipped (tool missing):%s %s\n" "$Y" "$X" "${skipped[*]}"


### PR DESCRIPTION
Closes #8

## What changed

### `tests/check.sh`
Added a new **Hyprland** section after the JSON section that runs a syntax check on each of the four `.conf` files in `hypr/`:
- `hypr/hyprland.conf`
- `hypr/hyprlock.conf`
- `hypr/hypridle.conf`
- `hypr/hyprpaper.conf`

**Check strategy (in priority order):**
1. **`hyprland` binary available (primary / CI path):** Launches `hyprland --config <file>` with `WLR_BACKENDS=headless WLR_RENDERER=pixman` and a 5-second timeout so no display is needed. Hyprland parses the config file before touching any display backend, so config parse errors surface in the output regardless. A timeout exit (rc 124) means the compositor started cleanly past config-parsing → config is valid. For early exits, the output is scanned for config-specific error patterns (`[Config].*Error`, `Unknown (variable|category|keyword)`, `Parse Error`).
2. **`hyprctl` available and a compositor is running (`$HYPRLAND_INSTANCE_SIGNATURE` set):** Sends `hyprctl --config-path <file> configreload` to the running compositor and checks the response for error messages.
3. **Neither available:** Skips gracefully with a `∼ skip hyprctl / hyprland (install via 'nix develop')` message.

### `flake.nix`
Added `hyprland` (Linux-only, via `lib.optionals stdenv.isLinux`) to the `nix develop` devShell. The `hyprland` package provides both the `hyprland` compositor binary and `hyprctl`. It is guarded to Linux so the macOS (`aarch64-darwin`) devShell is unaffected.

## Test / build result

- `bash -n tests/check.sh` — ✓ passes (no syntax errors)
- `shellcheck tests/check.sh` — ✓ passes (no warnings)
- `shfmt -d -i 4 -ci tests/check.sh` — ✓ no diff (formatting unchanged)
- Nix tools (`nixpkgs-fmt`, `statix`, `deadnix`) not run in this environment but the flake.nix edit is minimal and follows the existing style.

> **Note:** The grep patterns for Hyprland config errors (`[Config].*Error` etc.) may need adjustment if the installed Hyprland version logs errors with a different format. The headless timeout approach is the most reliable CI path; the patterns are a secondary safety net for quick-exit cases.

🤖 AI-generated — review before merging.