### PR TITLE
fix: re-wrap vim.notify after LazyDone to restore errorlog (#10)

### DIFF
--- a/nvim/lua/config/errorlog.lua
+++ b/nvim/lua/config/errorlog.lua
@@ -20,16 +20,34 @@ local function append(lines)
 end
 
 -- Wrap vim.notify so WARN/ERROR messages also land in the log.
-local original_notify = vim.notify
-vim.notify = function(msg, level, opts)
-    level = level or vim.log.levels.INFO
-    if type(msg) == "string" and level >= vim.log.levels.WARN then
-        local label = level >= vim.log.levels.ERROR and "ERROR" or "WARN"
-        append({ string.format("[%s] [notify:%s] %s",
-            timestamp(), label, (msg:gsub("\n", " | "))) })
+-- Returns a new function that logs WARN/ERROR and delegates to `base`.
+local function make_logging_notify(base)
+    return function(msg, level, opts)
+        level = level or vim.log.levels.INFO
+        if type(msg) == "string" and level >= vim.log.levels.WARN then
+            local label = level >= vim.log.levels.ERROR and "ERROR" or "WARN"
+            append({ string.format("[%s] [notify:%s] %s",
+                timestamp(), label, (msg:gsub("\n", " | "))) })
+        end
+        return base(msg, level, opts)
     end
-    return original_notify(msg, level, opts)
 end
+
+vim.notify = make_logging_notify(vim.notify)
+
+local group = vim.api.nvim_create_augroup("ErrorLog", { clear = true })
+
+-- Re-assert the wrapper after lazy.nvim finishes loading plugins.
+-- Some plugins (e.g. nvim-notify) replace vim.notify outright in their
+-- `init` callbacks, silently dropping this logging layer.
+vim.api.nvim_create_autocmd("User", {
+    pattern = "LazyDone",
+    once    = true,
+    group   = group,
+    callback = function()
+        vim.notify = make_logging_notify(vim.notify)
+    end,
+})
 
 -- Snapshot LSP diagnostics for a buffer shortly after :write,
 -- giving the language server a moment to report against the
@@ -56,7 +74,6 @@ local function snapshot_buffer(bufnr)
     append(lines)
 end
 
-local group = vim.api.nvim_create_augroup("ErrorLog", { clear = true })
 vim.api.nvim_create_autocmd("BufWritePost", {
     group = group,
     callback = function(args)


### PR DESCRIPTION
Closes #10

## What changed

`nvim/lua/config/errorlog.lua` had its `vim.notify` wrapper silently discarded once lazy.nvim loaded nvim-notify, because nvim-notify's `init` callback replaces `vim.notify` outright.

**Fix:** Extracted the wrapping logic into a `make_logging_notify(base)` helper and added a one-shot `User LazyDone` autocmd that re-applies the wrapper around whatever `vim.notify` is current at that point (i.e., the nvim-notify version). The `ErrorLog` augroup is now created once, before both autocmds, so the group doesn't accidentally `clear = true` the `LazyDone` listener.

After this change:
- At startup: errorlog wraps the default `vim.notify`
- After plugins load (`LazyDone`): errorlog re-wraps nvim-notify's `vim.notify`
- `vim.notify("x", vim.log.levels.ERROR)` now appends to `~/.cache/nvim/error.log` even with nvim-notify active
- nvim-notify still renders notifications visually (the wrapper delegates to it)

## Test / build result

`tests/check.sh` was run. Shell and JSON checks passed. Nix checks were skipped (nix-instantiate not available in CI — pre-existing, unrelated to this change). Lua syntax check was skipped (luac not in PATH in CI). No new failures introduced.

🤖 AI-generated — review before merging.