### PR TITLE
fix: add vlang + v-analyzer to system packages (#12)

### DIFF
--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -78,6 +78,10 @@ in
     php.packages.composer
     intelephense
     phpPackages.php-cs-fixer
+
+    # V: compiler/runtime (provides `v` for v_fmt formatter on save) + LSP.
+    vlang
+    v-analyzer
   ];
 
   # ---------- Fonts (system-wide, so kitty & friends can discover them) ----------

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -166,6 +166,7 @@
     gdb
     nasm
     nodejs_20
+    vlang # V toolchain — provides `v` binary for v_fmt formatter (conform.nvim)
 
     # Language servers (consumed by nvim-lspconfig from $PATH)
     gopls
@@ -176,6 +177,7 @@
     lua-language-server
     bash-language-server
     nil
+    v-analyzer # V LSP server (binary: `v-analyzer`; matches lsp.lua v_analyzer entry)
     intelephense # PHP / Laravel LSP
 
     # PHP / Laravel toolchain. `php` is needed at runtime (Pint/php-cs-fixer


### PR DESCRIPTION
Closes #12

## What changed and why

`nvim/lua/plugins/lsp.lua` registers the `v_analyzer` LSP server and a `v_fmt` conform formatter that shells out to `v fmt -w <file>` on every `.v` file save. Neither `vlang` (which provides the `v` binary) nor `v-analyzer` was installed by any host configuration, so on a freshly-rebuilt machine:
- The LSP silently fails to start (`v-analyzer` not on `$PATH`).
- Every `:w` on a `.v` file raises a "v: executable not found" formatter error.

This PR adds the missing packages to both host configurations:

- **`nixos/configuration.nix`** — `vlang` under "Compilers / build tools" (provides `v` for the formatter) and `v-analyzer` under "Language servers" (the LSP binary).
- **`darwin/configuration.nix`** — same pair under `environment.systemPackages`, alongside the existing Go/PHP toolchain entries.

After a `nixos-rebuild switch` / `darwin-rebuild switch`, opening a `.v` file will attach the LSP and saving will format cleanly without errors.

## Test / build result

CI validates nix syntax (`nix-instantiate --parse`), formatting (`nixpkgs-fmt --check`), and static analysis (`statix`, `deadnix`) — none of which evaluate the NixOS/Darwin configurations, so CI passes for parse/format correctness. Full evaluation (confirming `vlang` and `v-analyzer` resolve in `nixpkgs-unstable`) requires a local `nixos-rebuild dry-build` or `darwin-rebuild build`, which cannot run in this environment.

Both `vlang` and `v-analyzer` are present in `nixpkgs-unstable` (the channel pinned in `flake.nix`).

🤖 AI-generated — review before merging.