### PR TITLE
fix(home): use correct programs.git.userName/userEmail options (#16)

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -48,10 +48,8 @@
   # ---------- Native HM modules ----------
   programs.git = {
     enable = true;
-    settings.user = {
-      name = "v420v";
-      email = "ibuki420v@gmail.com";
-    };
+    userName = "v420v";
+    userEmail = "ibuki420v@gmail.com";
   };
 
   programs.starship = {


### PR DESCRIPTION
Closes #16

## What changed and why

`home/common.nix` was setting git identity through `programs.git.settings.user.{name,email}`, but the home-manager `programs.git` module **has no `settings` option**. This caused every host that imports `common.nix` to either fail evaluation with `The option 'programs.git.settings' does not exist` or silently ignore the block — either way the configured git name/email were never written to disk.

The fix replaces the invalid attribute path with the correct home-manager options:

```nix
programs.git = {
  enable = true;
  userName  = "v420v";
  userEmail = "ibuki420v@gmail.com";
};
```

These map to `user.name` / `user.email` in `~/.config/git/config` after a rebuild.

## Test / build result

`nix` tooling (`nix-instantiate`, `statix`, `nixpkgs-fmt`) is not available in the CI runner environment — all Nix-related checks were skipped with "install via nix develop". Shell syntax checks (`bash -n`, `shellcheck`) and JSON checks (`jq`) all passed. The change is a straightforward attribute-name correction with no logic involved.

🤖 AI-generated — review before merging.