### PR TITLE
fix: correct windowrule syntax in hyprland.conf (#17)

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -122,14 +122,14 @@ input {
 gesture = 3, horizontal, workspace
 
 # ── Window rules ──────────────────────────────────────────
-windowrule = float on, match:class ^(pavucontrol)$
-windowrule = float on, match:class ^(blueman-manager)$
-windowrule = float on, match:class ^(nm-connection-editor)$
-windowrule = float on, match:title ^(Picture-in-Picture)$
-windowrule = float on, match:class ^(file-roller)$
-windowrule = opacity 0.92 0.85, match:class ^(kitty)$
-windowrule = opacity 0.97 0.90, match:class ^(thunar)$
-windowrule = suppress_event maximize, match:class .*
+windowrule = float, class:^(pavucontrol)$
+windowrule = float, class:^(blueman-manager)$
+windowrule = float, class:^(nm-connection-editor)$
+windowrule = float, title:^(Picture-in-Picture)$
+windowrule = float, class:^(file-roller)$
+windowrule = opacity 0.92 0.85, class:^(kitty)$
+windowrule = opacity 0.97 0.90, class:^(thunar)$
+windowrule = suppress_event maximize, class:.*
 
 # ── Keybinds ──────────────────────────────────────────────
 # Apps


### PR DESCRIPTION
Closes #17

## What changed

All 8 `windowrule` lines in `hypr/hyprland.conf` (lines 125–132) used invalid syntax in two ways:

1. **`float on`** — `float` takes no argument; the correct rule is just `float`.
2. **`match:class` / `match:title`** — there is no `match:` prefix in Hyprland's `windowrule` syntax; the correct form is `class:` / `title:` directly after the comma.

Fixed to the correct `windowrule = RULE, FIELD:REGEX` format:

```diff
-windowrule = float on, match:class ^(pavucontrol)$
+windowrule = float, class:^(pavucontrol)$
-windowrule = float on, match:class ^(blueman-manager)$
+windowrule = float, class:^(blueman-manager)$
-windowrule = float on, match:class ^(nm-connection-editor)$
+windowrule = float, class:^(nm-connection-editor)$
-windowrule = float on, match:title ^(Picture-in-Picture)$
+windowrule = float, title:^(Picture-in-Picture)$
-windowrule = float on, match:class ^(file-roller)$
+windowrule = float, class:^(file-roller)$
-windowrule = opacity 0.92 0.85, match:class ^(kitty)$
+windowrule = opacity 0.92 0.85, class:^(kitty)$
-windowrule = opacity 0.97 0.90, match:class ^(thunar)$
+windowrule = opacity 0.97 0.90, class:^(thunar)$
-windowrule = suppress_event maximize, match:class .*
+windowrule = suppress_event maximize, class:.*
```

## Why

Hyprland rejected all 8 rules at startup due to the invalid matcher prefix and the spurious `on` argument, meaning pavucontrol/blueman/nm-connection-editor/PiP/file-roller never floated, kitty/thunar never received their opacity settings, and maximize suppression never fired.

## Test / build result

This is a dotfiles repo with no automated test suite. The fix is a mechanical syntax correction matching the [Hyprland wiki](https://wiki.hyprland.org/Configuring/Window-Rules/). Manual verification requires a running Hyprland session; startup parse errors should disappear after applying this change.

🤖 AI-generated — review before merging.