### PR TITLE
fix: rebind hyprlock to SUPER+SHIFT+L to resolve SUPER+L conflict (#18)

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -146,7 +146,7 @@ bind = $mod, F,        fullscreen,
 bind = $mod, T,        togglefloating,
 bind = $mod, P,        pseudo,
 bind = $mod, J,        togglesplit,
-bind = $mod, L,        exec, hyprlock
+bind = $mod SHIFT, L,  exec, hyprlock
 
 # Focus
 bind = $mod, left,  movefocus, l


### PR DESCRIPTION
Closes #18

## What changed

In `hypr/hyprland.conf`, `$mod, L` was bound to two different actions:
- Line 149: `exec, hyprlock` (screen lock)
- Line 157: `movefocus, r` (vim-style focus right)

Hyprland treats letter binds case-insensitively, so both resolved to the same key combination (`SUPER+L`). Hyprland kept the first binding and silently ignored the second, making `movefocus r` unreachable via the `l` key.

**Fix:** Move the hyprlock binding to `$mod SHIFT, L` (i.e. `SUPER+SHIFT+L`), which is unoccupied and consistent with the pattern of `$mod SHIFT` being used for destructive/global operations elsewhere in the config.

```diff
-bind = $mod, L,        exec, hyprlock
+bind = $mod SHIFT, L,  exec, hyprlock
```

The vim-style focus binding `$mod, l` for `movefocus, r` is unchanged.

## Test / build result

This is a dotfiles/config-only repo with no build system or test suite. The change is a single-line edit to a Hyprland config file — no compilation or tests to run.

## Notes

🤖 AI-generated — review before merging.