### PR TITLE
nvim: fix duplicate lazy.nvim key specs shadowing each other (#19)

### DIFF
--- a/nvim/lua/plugins/claude.lua
+++ b/nvim/lua/plugins/claude.lua
@@ -30,7 +30,7 @@ return {
         },
         keys = {
             { "<leader>cc", "<cmd>ClaudeCode<CR>",          mode = "n", desc = "Toggle Claude" },
-            { "<leader>cf", "<cmd>ClaudeCodeFocus<CR>",     mode = "n", desc = "Focus Claude window" },
+            { "<leader>cF", "<cmd>ClaudeCodeFocus<CR>",     mode = "n", desc = "Focus Claude window" },
             { "<leader>cR", "<cmd>ClaudeCode --resume<CR>", mode = "n", desc = "Resume Claude session" },
             { "<leader>cC", "<cmd>ClaudeCode --continue<CR>", mode = "n", desc = "Continue Claude session" },
             -- File / selection context

--- a/nvim/lua/plugins/editor.lua
+++ b/nvim/lua/plugins/editor.lua
@@ -78,7 +78,7 @@ return {
         cmd = { "DiffviewOpen", "DiffviewClose", "DiffviewToggleFiles", "DiffviewFileHistory", "DiffviewRefresh" },
         keys = {
             { "<leader>gd", "<cmd>DiffviewOpen<CR>",          desc = "Diff: open changes" },
-            { "<leader>gc", "<cmd>DiffviewClose<CR>",         desc = "Diff: close" },
+            { "<leader>gq", "<cmd>DiffviewClose<CR>",         desc = "Diff: close" },
             { "<leader>gh", "<cmd>DiffviewFileHistory<CR>",   desc = "Diff: repo history" },
             { "<leader>gH", "<cmd>DiffviewFileHistory %<CR>", desc = "Diff: file history" },
             { "<leader>gf", "<cmd>DiffviewToggleFiles<CR>",   desc = "Diff: toggle files panel" },


### PR DESCRIPTION
Closes #19

## What changed

Two pairs of `keys` entries in the lazy.nvim plugin specs shared the same `lhs`+mode, causing non-deterministic shadowing:

| Conflict | Before | After |
|---|---|---|
| Claude focus vs. conform format | both used `<leader>cf` (normal) | Claude focus → `<leader>cF` |
| Telescope git commits vs. Diffview close | both used `<leader>gc` (normal) | Diffview close → `<leader>gq` |

**Files changed:**
- `nvim/lua/plugins/claude.lua` — `<leader>cf` → `<leader>cF` for "Focus Claude window"
- `nvim/lua/plugins/editor.lua` — `<leader>gc` → `<leader>gq` for "Diff: close"

All four actions (Claude focus, format buffer, git commits, diffview close) are now individually reachable via unique keys.

## Why these keys

Follows the issue's suggested fix: keep the more common/expected binding on the original key (`<leader>cf` = format, `<leader>gc` = git commits) and move the less frequently-used duplicate to a nearby key (uppercase `F` for focus; `q` for quit/close).

## Test / build result

This is a Neovim Lua config (dotfiles); no automated test suite present. Changes are syntactically valid Lua — the only modification is the `lhs` string in two `keys` table entries.

🤖 AI-generated — review before merging.