### PR TITLE
nvim: fix buffer-local LSP keymap collisions with Claude diff and window-nav (#20)

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -45,12 +45,12 @@ return {
                     map("n", "gi",         vim.lsp.buf.implementation,  "Implementation")
                     map("n", "gt",         vim.lsp.buf.type_definition, "Type definition")
                     map("n", "K",          vim.lsp.buf.hover,           "Hover")
-                    map("n", "<C-k>",      vim.lsp.buf.signature_help,  "Signature help")
+                    map("n", "<leader>ls", vim.lsp.buf.signature_help,  "Signature help")
                     map("n", "<leader>rn", vim.lsp.buf.rename,          "Rename symbol")
-                    map({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, "Code action")
+                    map({ "n", "v" }, "<leader>la", vim.lsp.buf.code_action, "Code action")
                     map("n", "[d",         vim.diagnostic.goto_prev,    "Prev diagnostic")
                     map("n", "]d",         vim.diagnostic.goto_next,    "Next diagnostic")
-                    map("n", "<leader>cd", vim.diagnostic.open_float,   "Show diagnostic")
+                    map("n", "<leader>ld", vim.diagnostic.open_float,   "Show diagnostic")
                     map("n", "<leader>cl", "<cmd>LspInfo<CR>",          "LSP info")
 
                     -- Auto-hover: when the cursor rests on a symbol (updatetime


### PR DESCRIPTION
Closes #20

## What changed

Three buffer-local keymaps set in the `LspAttach` callback (`nvim/lua/plugins/lsp.lua`) were shadowing global maps in every LSP-attached buffer:

| Old binding | Action | Conflict |
|---|---|---|
| `<C-k>` | `vim.lsp.buf.signature_help` | shadows `<C-w>k` (window up) from `keymaps.lua:29` |
| `<leader>ca` | `vim.lsp.buf.code_action` | shadows `ClaudeCodeDiffAccept` from `claude.lua:44` |
| `<leader>cd` | `vim.diagnostic.open_float` | shadows `ClaudeCodeDiffDeny` from `claude.lua:45` |

Replaced with LSP-namespaced keys that have no existing bindings:

| New binding | Action |
|---|---|
| `<leader>ls` | Signature help |
| `<leader>la` | Code action |
| `<leader>ld` | Show diagnostic float |

## Why

Buffer-local maps always take precedence over global maps in Neovim, so the `LspAttach`-registered bindings were permanently overriding:
- `<C-h/j/k/l>` window navigation (only `<C-k>` was affected here)
- The Claude diff accept/deny workflow — the primary use-case of the Claude integration

## Test / build result

This is a dotfiles/Neovim config repository with no automated test suite. The change is a pure keymap remap; correctness can be validated by opening a file with an LSP attached and verifying `<C-k>`, `<leader>ca`, and `<leader>cd` invoke their global actions.

🤖 AI-generated — review before merging.