### PR TITLE
nvim/lsp.lua: fix deprecated diagnostic jump and conform lsp_fallback APIs (#21)

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -48,8 +48,8 @@ return {
                     map("n", "<C-k>",      vim.lsp.buf.signature_help,  "Signature help")
                     map("n", "<leader>rn", vim.lsp.buf.rename,          "Rename symbol")
                     map({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, "Code action")
-                    map("n", "[d",         vim.diagnostic.goto_prev,    "Prev diagnostic")
-                    map("n", "]d",         vim.diagnostic.goto_next,    "Next diagnostic")
+                    map("n", "[d", function() vim.diagnostic.jump({ count = -1, float = true }) end, "Prev diagnostic")
+                    map("n", "]d", function() vim.diagnostic.jump({ count =  1, float = true }) end, "Next diagnostic")
                     map("n", "<leader>cd", vim.diagnostic.open_float,   "Show diagnostic")
                     map("n", "<leader>cl", "<cmd>LspInfo<CR>",          "LSP info")
 
@@ -150,7 +150,7 @@ return {
         keys  = {
             {
                 "<leader>cf",
-                function() require("conform").format({ async = true, lsp_fallback = true }) end,
+                function() require("conform").format({ async = true, lsp_format = "fallback" }) end,
                 mode = { "n", "v" },
                 desc = "Format buffer",
             },
@@ -201,7 +201,7 @@ return {
             format_on_save = function(bufnr)
                 -- Disable with :FormatDisable on a buffer or globally.
                 if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then return end
-                return { timeout_ms = 1500, lsp_fallback = true }
+                return { timeout_ms = 1500, lsp_format = "fallback" }
             end,
         } end,
         init = function()


### PR DESCRIPTION
Closes #21

## What changed

Replaced three deprecated Neovim/conform API usages in `nvim/lua/plugins/lsp.lua`:

1. **Diagnostic navigation keymaps** (lines 51–52): replaced the deprecated `vim.diagnostic.goto_prev` / `vim.diagnostic.goto_next` (removed in nvim 0.11) with `vim.diagnostic.jump({ count = -1, float = true })` / `vim.diagnostic.jump({ count = 1, float = true })`, wrapped in lambda functions. The `float = true` keeps the floating diagnostic window on jump, matching the previous behaviour.

2. **`<leader>cf` format keymap** (line 153): replaced `lsp_fallback = true` with `lsp_format = "fallback"` in the conform format call.

3. **`format_on_save`** (line 204): same `lsp_fallback = true` → `lsp_format = "fallback"` substitution.

## Why

`vim.diagnostic.goto_prev`/`goto_next` are deprecated since nvim 0.11 and scheduled for removal. conform's `lsp_fallback` option is deprecated in favour of `lsp_format`. Each `[d`/`]d` press and each format-on-save was emitting deprecation warnings.

## Test / build result

The project's test script (`tests/check.sh`) requires `nix develop` for most tooling (nix-instantiate, luac, statix, etc.) which is not available in this CI environment — those checks are pre-existing skips. Shell syntax (`bash -n`, `shellcheck`) and JSON lint (`jq`) passed. The Lua change is a pure token substitution with no structural changes.

🤖 AI-generated — review before merging.