### PR TITLE
darwin: add missing LSP servers and formatters to systemPackages (#36)

### DIFF
--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -86,19 +86,19 @@ in
     # Language servers (consumed by nvim-lspconfig from $PATH).
     # These mirror the LSP entries in nvim/lua/plugins/lsp.lua and must be kept
     # in sync with the equivalent list in nixos/configuration.nix.
-    clang-tools              # clangd (C/C++) + clang-format (conform.nvim)
+    clang-tools # clangd (C/C++) + clang-format (conform.nvim)
     typescript-language-server # ts_ls
     vscode-langservers-extracted # html / cssls / jsonls / eslint
-    asm-lsp                  # asm_lsp (x86/ARM/RISC-V intrinsics)
-    lua-language-server      # lua_ls
-    bash-language-server     # bashls
-    nil                      # nil_ls (Nix)
+    asm-lsp # asm_lsp (x86/ARM/RISC-V intrinsics)
+    lua-language-server # lua_ls
+    bash-language-server # bashls
+    nil # nil_ls (Nix)
 
     # Formatters (consumed by conform.nvim from $PATH).
-    prettierd   # JS/TS/HTML/CSS/JSON/YAML/Markdown
-    stylua      # Lua
+    prettierd # JS/TS/HTML/CSS/JSON/YAML/Markdown
+    stylua # Lua
     nixpkgs-fmt # Nix
-    shfmt       # shell
+    shfmt # shell
   ];
 
   # ---------- Fonts (system-wide, so kitty & friends can discover them) ----------

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -82,6 +82,23 @@ in
     # V: compiler/runtime (provides `v` for v_fmt formatter on save) + LSP.
     vlang
     v-analyzer
+
+    # Language servers (consumed by nvim-lspconfig from $PATH).
+    # These mirror the LSP entries in nvim/lua/plugins/lsp.lua and must be kept
+    # in sync with the equivalent list in nixos/configuration.nix.
+    clang-tools              # clangd (C/C++) + clang-format (conform.nvim)
+    typescript-language-server # ts_ls
+    vscode-langservers-extracted # html / cssls / jsonls / eslint
+    asm-lsp                  # asm_lsp (x86/ARM/RISC-V intrinsics)
+    lua-language-server      # lua_ls
+    bash-language-server     # bashls
+    nil                      # nil_ls (Nix)
+
+    # Formatters (consumed by conform.nvim from $PATH).
+    prettierd   # JS/TS/HTML/CSS/JSON/YAML/Markdown
+    stylua      # Lua
+    nixpkgs-fmt # Nix
+    shfmt       # shell
   ];
 
   # ---------- Fonts (system-wide, so kitty & friends can discover them) ----------


### PR DESCRIPTION
Closes #36

## What changed

Added the following packages to `darwin/configuration.nix` `environment.systemPackages`, matching the set already present in `nixos/configuration.nix`:

**Language servers** (consumed by `nvim-lspconfig` from `$PATH`):
- `clang-tools` — provides `clangd` (C/C++) and `clang-format` (used by conform.nvim)
- `typescript-language-server` — `ts_ls`
- `vscode-langservers-extracted` — `html`, `cssls`, `jsonls`, `eslint`
- `asm-lsp` — `asm_lsp` (x86/ARM/RISC-V intrinsics)
- `lua-language-server` — `lua_ls`
- `bash-language-server` — `bashls`
- `nil` — `nil_ls` (Nix)

**Formatters** (consumed by `conform.nvim` from `$PATH`):
- `prettierd` — JS/TS/HTML/CSS/JSON/YAML/Markdown
- `stylua` — Lua
- `nixpkgs-fmt` — Nix
- `shfmt` — shell

## Why

`nvim/lua/plugins/lsp.lua` enables these servers and formatters for all hosts, but `darwin/configuration.nix` only installed the Go, PHP, and V toolchains — leaving TypeScript, Lua, Nix, shell, C, and assembly files without LSP or format-on-save on macOS. All package names are taken verbatim from `nixos/configuration.nix` where they already work.

## Test / build result

Nix toolchain (`nix-instantiate`, `statix`, `deadnix`, `nixpkgs-fmt`) is not available in the CI environment — these checks were skipped with a warning. Shell syntax (`bash -n`, `shellcheck`) and JSON validation (`jq`) passed. The package names are identical to those already used in `nixos/configuration.nix`.

🤖 AI-generated — review before merging.