### PR TITLE
starship: symlink starship.toml, drop inline Nix settings (#37)

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -57,35 +57,6 @@
   programs.starship = {
     enable = true;
     enableZshIntegration = true;
-    settings = {
-      format = "$directory$git_branch$git_status$character";
-      add_newline = false;
-
-      directory = {
-        style = "blue";
-        format = "[$path]($style) ";
-        truncation_length = 3;
-        truncation_symbol = "…/";
-        home_symbol = "~";
-      };
-
-      git_branch = {
-        symbol = "";
-        style = "purple";
-        format = "[$branch]($style) ";
-      };
-
-      git_status = {
-        style = "yellow";
-        format = "[$all_status$ahead_behind]($style) ";
-      };
-
-      character = {
-        success_symbol = "[❯](green)";
-        error_symbol = "[❯](red)";
-        vimcmd_symbol = "[❮](purple)";
-      };
-    };
   };
 
   programs.fzf = {
@@ -279,12 +250,13 @@
   };
 
   # ---------- Dotfiles that stay as plain config files ----------
-  # Symlinked into ~/.config so editing the repo is a live edit. These three
+  # Symlinked into ~/.config so editing the repo is a live edit. These four
   # are portable; Hyprland/waybar/rofi/dunst symlinks are added in
   # home/ibuki.nix (Linux only).
   xdg.configFile = {
     "fastfetch".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/fastfetch";
     "nvim".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/nvim";
     "kitty/kitty.conf".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/kitty/kitty.conf";
+    "starship.toml".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/starship/starship.toml";
   };
 }


### PR DESCRIPTION
Closes #37

## What changed and why

`starship/starship.toml` was never referenced by any Nix file — the inline `programs.starship.settings` block in `home/common.nix` was the live config, and home-manager rendered it to `~/.config/starship.toml`. The standalone TOML file was a dead duplicate, while CI continued to lint it as if it were authoritative.

This PR implements **Option B** from the issue: make `starship/starship.toml` the single source of truth, consistent with how `nvim`, `fastfetch`, and `kitty/kitty.conf` are managed.

**Changes in `home/common.nix`:**
- Removed the `settings = { ... }` block from `programs.starship` (home-manager will no longer generate `~/.config/starship.toml` from Nix).
- Added `xdg.configFile."starship.toml".source = config.lib.file.mkOutOfStoreSymlink "…/dotfiles/starship/starship.toml"` so the repo file is symlinked live into `~/.config/starship.toml`.

The TOML file itself is unchanged — it already matches what the inline settings produced (plus the `$schema` declaration). The `taplo` checks in `tests/check.sh`, `tests/format.sh`, and `.github/workflows/ci.yml` now validate a file that is actually used.

## Test / build result

Nix and taplo are not available in the CI environment where this PR was authored. The Nix file change is syntactically straightforward (removing a `settings` attribute set, adding one `xdg.configFile` entry following the existing pattern). Shell script syntax checks pass. The existing CI workflow will provide the authoritative Nix build + taplo lint result.

🤖 AI-generated — review before merging.