### PR TITLE
alpha.lua: stop and close dashboard clock timer on BufUnload (#38)

### DIFF
--- a/nvim/lua/plugins/alpha.lua
+++ b/nvim/lua/plugins/alpha.lua
@@ -90,20 +90,25 @@ return {
             end,
         })
 
-        -- A live clock looks better than a frozen timestamp.
-        local timer = (vim.uv or vim.loop).new_timer()
-        timer:start(0, 1000, vim.schedule_wrap(function()
-            if vim.bo.filetype ~= "alpha" then return end
-            dashboard.section.footer.val = footer()
-            pcall(vim.cmd.AlphaRedraw)
-        end))
-
-        -- Hide cursor / end-of-buffer tildes on the dashboard.
+        -- A live clock scoped to each Alpha buffer: start on FileType, stop on BufUnload.
         vim.api.nvim_create_autocmd("FileType", {
             pattern  = "alpha",
-            callback = function()
+            callback = function(ev)
                 vim.opt_local.cursorline = false
                 vim.opt_local.fillchars  = { eob = " " }
+                local clock = (vim.uv or vim.loop).new_timer()
+                clock:start(0, 1000, vim.schedule_wrap(function()
+                    dashboard.section.footer.val = footer()
+                    pcall(vim.cmd.AlphaRedraw)
+                end))
+                vim.api.nvim_create_autocmd("BufUnload", {
+                    buffer   = ev.buf,
+                    once     = true,
+                    callback = function()
+                        clock:stop()
+                        clock:close()
+                    end,
+                })
             end,
         })
     end,


### PR DESCRIPTION
Closes #38

## What changed

Replaced the global always-running libuv timer with a timer that is scoped to the lifetime of each Alpha buffer:

- **Before:** a single `new_timer()` was created at plugin load time and fired every second for the entire Neovim session. Its callback early-returned when `filetype ~= "alpha"`, but the timer itself was never stopped or closed — leaving a permanent 1 Hz wakeup and a leaked handle.
- **After:** the timer is created inside the `FileType alpha` autocmd callback (which also handles cursor/fillchars local options). A `BufUnload` autocmd pinned to that specific buffer (`buffer = ev.buf, once = true`) calls `clock:stop()` and `clock:close()` the moment the dashboard buffer is unloaded.

The two previously-separate autocmd blocks (`FileType alpha` for options, standalone timer) are merged into one, eliminating the redundancy.

## Why

The fix satisfies the acceptance criteria from the issue:
- After leaving the Alpha dashboard, the 1-second timer no longer fires.
- The timer handle is closed (`clock:close()`), not merely stopped.

## Test / build result

This is a Lua Neovim config with no automated test suite. The change can be verified manually by inspecting the timer with `:lua print(clock:is_active())` before and after leaving the dashboard, or by adding a counter and confirming it stops incrementing once the alpha buffer is unloaded.

🤖 AI-generated — review before merging.