### PR TITLE
darwin: make docker-desktop cask conditional on !isWork (#40)

### DIFF
--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -150,9 +150,12 @@ in
       "zed"
       "coteditor"
       "postman"
-      "docker-desktop"
       # Communication
       "discord"
+    ] ++ lib.optionals (!isWork) [
+      # MDM-managed on the work Mac (yoshida) — Homebrew can't adopt or modify
+      # it and `brew bundle` aborts the whole rebuild if it's in the list.
+      "docker-desktop"
     ];
   };
 


### PR DESCRIPTION
Closes #40

## What changed and why

`darwin/configuration.nix` already defines `isWork = username == "yoshida"` with a comment explaining that MDM-managed apps like Docker Desktop can't be managed by Homebrew on the work Mac. However, `docker-desktop` was unconditionally included in the `casks` list, causing `brew bundle` to abort during `darwin-rebuild` on the work Mac.

This fix wraps `docker-desktop` in `lib.optionals (!isWork) [...]`, appended to the casks list, so it is only included for the personal Mac (`ibuki`). The pattern is consistent with how `isWork` is already used to gate `services.yabai.enable` and `services.skhd.enable`.

**Before:**
```nix
casks = [
  ...
  "docker-desktop"
  ...
];
```

**After:**
```nix
casks = [
  ...
] ++ lib.optionals (!isWork) [
  "docker-desktop"
];
```

## Test / build result

Nix is not available in the CI environment where this was implemented. The change is syntactically straightforward and uses the same `lib.optionals` idiom already present in `nixpkgs`. Manual verification on the target hosts (personal `ibuki` and work `yoshida` Macs) is recommended before merging.

🤖 AI-generated — review before merging.