### PR TITLE
home/darwin.nix: replace coreutils with coreutils-prefixed + gnused (#41)

### DIFF
--- a/home/darwin.nix
+++ b/home/darwin.nix
@@ -20,10 +20,13 @@
     # only, so we just take the packaged aarch64-darwin build here).
     claude-code
 
-    # GNU coreutils, so the shared GNU-style aliases/flags behave the same as
-    # on NixOS. Exposed g-prefixed (gls, gsed, ...) to avoid shadowing the BSD
-    # tools macOS itself depends on.
-    coreutils
+    # GNU coreutils in g-prefixed form (gls, gcp, gdate, gstat, …) so the GNU
+    # tools coexist with the BSD userland macOS depends on — bare ls/date/stat
+    # still resolve to /usr/bin. gnused provides gsed (it is not part of
+    # coreutils). Use these prefixed names in shared scripts/aliases that need
+    # GNU flag semantics on both NixOS and macOS.
+    coreutils-prefixed
+    gnused
 
     # Animated pipes terminal screensaver (pipeseroni/pipes.sh).
     pipes


### PR DESCRIPTION
Closes #41

## What changed and why

`home/darwin.nix` was installing the `coreutils` nixpkgs package, which exposes **unprefixed** GNU binaries (`ls`, `cp`, `date`, `stat`, …) that silently shadow the BSD userland macOS itself depends on — the opposite of what the comment claimed.

This PR:
- Replaces `coreutils` with **`coreutils-prefixed`**, which installs the same GNU tools under their `g`-prefixed names (`gls`, `gcp`, `gdate`, `gstat`, …) so bare `ls`/`date`/`stat` still resolve to `/usr/bin`.
- Adds **`gnused`** to provide `gsed`, which is not part of coreutils at all.
- Updates the comment to accurately describe the non-shadowing, g-prefixed behaviour and notes that `gnused` supplies `gsed`.

## Test / build result

`nix-instantiate` and the other Nix toolchain tools require `nix develop` and are not available in this CI environment; the Nix parse/lint steps were skipped (pre-existing, not caused by this change). Shell syntax checks (`bash -n`, `shellcheck`) and JSON validation (`jq`) all passed.

🤖 AI-generated — review before merging.