### PR TITLE
nvim: remove duplicate <leader>bd from keymaps.lua (#43)

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -38,7 +38,6 @@ map("n", "<C-Right>", "<cmd>vertical resize +2<CR>",   { desc = "Grow window hor
 -- Buffer navigation
 map("n", "<S-l>", "<cmd>bnext<CR>",          { desc = "Next buffer" })
 map("n", "<S-h>", "<cmd>bprevious<CR>",      { desc = "Prev buffer" })
-map("n", "<leader>bd", "<cmd>bdelete<CR>",   { desc = "Delete buffer" })
 
 -- Black-hole register so x / paste don't clobber the clipboard
 map({ "n", "v" }, "<leader>p", [["_dP]],     { desc = "Paste without yank" })


### PR DESCRIPTION
Closes #43

## What changed and why

`<leader>bd` was defined in two places:
- `nvim/lua/config/keymaps.lua` → `<cmd>bdelete<CR>` (closes buffer **and** window)
- `nvim/lua/plugins/editor.lua` → `mini.bufremove.delete` (preserves window layout)

lazy.nvim's key stubs override `keymaps.lua` bindings when the plugin loads, making the `:bdelete` mapping silently dead. This is confusing config drift.

**Fix:** remove the `<leader>bd` line from `keymaps.lua` and keep the `mini.bufremove` lazy key, which is the actively working one and has the better semantics (preserves window layout).

## Files changed

- `nvim/lua/config/keymaps.lua` — deleted the `<leader>bd` `<cmd>bdelete<CR>` line (1 line removed)

## Test / build result

This is a dotfiles repo with no automated test suite. The change is a single-line deletion of a dead mapping; no runtime errors are possible.

🤖 AI-generated — review before merging.