### PR TITLE
fix(errorlog): deduplicate diagnostics per file and cap log size (#44)

### DIFF
--- a/nvim/lua/config/errorlog.lua
+++ b/nvim/lua/config/errorlog.lua
@@ -4,6 +4,7 @@
 -- Claude Code can read them without opening nvim.
 
 local log_path = vim.fn.stdpath("cache") .. "/error.log"
+local MAX_LINES = 10000  -- hard cap; oldest lines are dropped when exceeded
 
 local function timestamp()
     return os.date("%Y-%m-%dT%H:%M:%S")
@@ -57,21 +58,75 @@ local severity_label = {
     [vim.diagnostic.severity.WARN]  = "WARN",
 }
 
+-- Last-written diagnostic set per file (keyed by content without timestamp,
+-- so repeated saves with identical diagnostics do not grow the log).
+local last_snapshot = {}
+
 local function snapshot_buffer(bufnr)
     if not vim.api.nvim_buf_is_valid(bufnr) then return end
     local fname = vim.api.nvim_buf_get_name(bufnr)
     if fname == "" then return end
-    local lines = {}
+
+    -- Build current diagnostic set as content strings (no timestamp).
+    local current = {}
     for _, d in ipairs(vim.diagnostic.get(bufnr)) do
         local label = severity_label[d.severity]
         if label then
-            table.insert(lines, string.format(
-                "[%s] [lsp:%s] %s:%d:%d: %s",
-                timestamp(), label, fname,
-                d.lnum + 1, d.col + 1, (d.message:gsub("\n", " | "))))
+            local key = string.format("[lsp:%s] %s:%d:%d: %s",
+                label, fname, d.lnum + 1, d.col + 1,
+                (d.message:gsub("\n", " | ")))
+            current[key] = true
         end
     end
-    append(lines)
+
+    -- Skip rewrite when diagnostics haven't changed since the last save.
+    local prev = last_snapshot[fname] or {}
+    local same = true
+    for k in pairs(current) do
+        if not prev[k] then same = false; break end
+    end
+    if same then
+        for k in pairs(prev) do
+            if not current[k] then same = false; break end
+        end
+    end
+    if same then return end
+    last_snapshot[fname] = current
+
+    -- Rewrite the log: drop old entries for this file, then append fresh set.
+    -- This prevents duplicate growth and ensures stale diagnostics are pruned.
+    local kept = {}
+    local lsp_prefix = "] " .. fname .. ":"
+    local f = io.open(log_path, "r")
+    if f then
+        for line in f:lines() do
+            if not (line:find(" [lsp:", 1, true) and line:find(lsp_prefix, 1, true)) then
+                table.insert(kept, line)
+            end
+        end
+        f:close()
+    end
+
+    local ts = timestamp()
+    for key in pairs(current) do
+        table.insert(kept, string.format("[%s] %s", ts, key))
+    end
+
+    -- Apply hard size cap: keep the most recent MAX_LINES lines.
+    if #kept > MAX_LINES then
+        local trimmed = {}
+        for i = #kept - MAX_LINES + 1, #kept do
+            table.insert(trimmed, kept[i])
+        end
+        kept = trimmed
+    end
+
+    local out = io.open(log_path, "w")
+    if not out then return end
+    for _, line in ipairs(kept) do
+        out:write(line .. "\n")
+    end
+    out:close()
 end
 
 vim.api.nvim_create_autocmd("BufWritePost", {
@@ -90,8 +145,10 @@ vim.api.nvim_create_user_command("ErrorLogPath", function()
 end, {})
 
 vim.api.nvim_create_user_command("ErrorLogClear", function()
-    local f = io.open(log_path, "w")
-    if f then f:close() end
+    local file = io.open(log_path, "w")
+    if file then file:close() end
+    -- Reset per-file cache so subsequent saves re-log diagnostics.
+    last_snapshot = {}
     vim.notify("Cleared " .. log_path)
 end, {})
 

--- a/nvim/lua/config/errorlog.lua
+++ b/nvim/lua/config/errorlog.lua
@@ -91,7 +91,6 @@ local function snapshot_buffer(bufnr)
         end
     end
     if same then return end
-    last_snapshot[fname] = current
 
     -- Rewrite the log: drop old entries for this file, then append fresh set.
     -- This prevents duplicate growth and ensures stale diagnostics are pruned.
@@ -127,6 +126,7 @@ local function snapshot_buffer(bufnr)
         out:write(line .. "\n")
     end
     out:close()
+    last_snapshot[fname] = current
 end
 
 vim.api.nvim_create_autocmd("BufWritePost", {


### PR DESCRIPTION
Closes #44

## What changed and why

`errorlog.lua`'s `snapshot_buffer` function previously used `append()` on every `BufWritePost`, writing the full diagnostic set each time with no deduplication. A file with N persistent warnings saved M times produced N×M duplicate lines and the log grew without bound.

### Changes in `nvim/lua/config/errorlog.lua`

1. **Per-file section rewrite instead of append** — when `snapshot_buffer` runs, it reads the existing log, strips all lines that belong to `fname` (identified by the `[lsp:*] fname:` literal pattern), then writes the fresh diagnostic set back. Old/stale diagnostics for that file are pruned automatically.

2. **Deduplication via `last_snapshot` cache** — diagnostic content (without timestamp) is stored per file. If the set is identical to the previous snapshot the rewrite is skipped entirely, so saving an unmodified file is a no-op.

3. **Hard size cap (`MAX_LINES = 10000`)** — after each rewrite the kept lines are trimmed to the most recent 10 000, satisfying the bounded-size acceptance criterion.

4. **`ErrorLogClear` resets the cache** — so that a manual clear followed by a save re-emits diagnostics as expected.

## Test / build result

The repo's `tests/check.sh` was run:
- Shell (bash -n, shellcheck): **all pass**
- JSON (jq): **all pass**
- Nix / Lua / TOML checks: **skipped** — Nix toolchain and `luac` are not available outside `nix develop`; all Nix failures are pre-existing (`nix-instantiate: command not found`) and unrelated to this change.

No Lua interpreter was available for a syntax check, but the file structure is straightforward Lua 5.1-compatible code with no advanced features.

🤖 AI-generated — review before merging.