### PR TITLE
hypr: fix SUPER+j double-bind — move togglesplit to SUPER+SHIFT+J (#46)

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -145,7 +145,7 @@ bind = $mod SHIFT, E,  exit,
 bind = $mod, F,        fullscreen,
 bind = $mod, T,        togglefloating,
 bind = $mod, P,        pseudo,
-bind = $mod, J,        togglesplit,
+bind = $mod SHIFT, J,  togglesplit,
 bind = $mod SHIFT, L,  exec, hyprlock
 
 # Focus


### PR DESCRIPTION
Closes #46

## What changed

In `hypr/hyprland.conf`, `$mod, J` (togglesplit) and `$mod, j` (movefocus down) resolved to the same chord (`SUPER+j`) because Hyprland matches letter binds case-insensitively when no explicit `SHIFT` modifier is present. This silently killed one of the two actions.

**Fix:** Changed line 148 from:
```
bind = $mod, J,        togglesplit,
```
to:
```
bind = $mod SHIFT, J,  togglesplit,
```

This keeps the vim-style `h/j/k/l` focus set intact (`SUPER+j` → move focus down) and gives togglesplit its own unambiguous chord (`SUPER+SHIFT+J`), consistent with the pattern used by similar window-management binds in the same block.

## Verification

This is a dotfiles/config-only change with no build or test toolchain. The fix was verified by inspection: the two formerly-colliding entries now have distinct modmasks (`$mod` vs `$mod SHIFT`), and no other binding in the file uses `$mod SHIFT, J`.

🤖 AI-generated — review before merging.