### PR TITLE
CI: add Nix store cache to format job (#47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          save-always: true
+
       - name: Verify formatting inside dev shell
         run: |
           nix develop --command bash -euo pipefail -c '


### PR DESCRIPTION
Closes #47

## What changed and why

Added `nix-community/cache-nix-action@v6` to the `format` job in `.github/workflows/ci.yml`, using the same `primary-key` and `restore-prefixes-first-match` settings already present in the `check` job.

Previously, the `format` job ran `nix develop` on every CI run without any Nix store cache, causing it to re-fetch and re-evaluate the entire dev shell (shfmt, nixpkgs-fmt, taplo, etc.) from scratch on every run. Since both jobs run on separate runners, the cache saved by `check` was never available to `format`.

The fix mirrors the exact same cache step from `check` into `format`, so both jobs now restore from cache on a cache hit (e.g. when `flake.lock` is unchanged).

## Test / build result

This is a CI workflow-only change (YAML). No build or test toolchain is applicable locally. The change is minimal and structurally identical to the existing cache step in the `check` job.

🤖 AI-generated — review before merging.