### PR TITLE
hypr: remove dead nm-applet autostart and nm-connection-editor rule (#56)

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -23,7 +23,6 @@ exec-once = waybar
 exec-once = bash -c 'hyprpaper & for i in $(seq 1 50); do hyprctl hyprpaper listactive >/dev/null 2>&1 && break; sleep 0.2; done; hyprctl hyprpaper wallpaper ",$HOME/dotfiles/wallpapers/wall.png"'
 exec-once = dunst
 exec-once = hypridle
-exec-once = nm-applet --indicator
 exec-once = blueman-applet
 exec-once = wl-paste --type text  --watch cliphist store
 exec-once = wl-paste --type image --watch cliphist store
@@ -124,7 +123,6 @@ gesture = 3, horizontal, workspace
 # ── Window rules ──────────────────────────────────────────
 windowrule = float on, match:class ^(pavucontrol)$
 windowrule = float on, match:class ^(blueman-manager)$
-windowrule = float on, match:class ^(nm-connection-editor)$
 windowrule = float on, match:title ^(Picture-in-Picture)$
 windowrule = float on, match:class ^(file-roller)$
 windowrule = opacity 0.92 0.85, match:class ^(kitty)$


### PR DESCRIPTION
Closes #56

## What changed and why

Removed two dead NetworkManager references from `hypr/hyprland.conf`:

1. **`exec-once = nm-applet --indicator`** (line 26) — This tried to launch the NetworkManager tray applet on every Hyprland login. The host uses **iwd** for Wi-Fi (not NetworkManager), `nm-applet` is not installed, and Wi-Fi status/management is already covered by the waybar `network` module with `impala`. The autostart silently failed every session.

2. **`windowrule = float on, match:class ^(nm-connection-editor)$`** (line 127) — A float rule for the NetworkManager GUI (`nm-connection-editor`), which is likewise not installed and can never match. Pure dead weight.

No functional change to networking: iwd + waybar `network` module + `impala` remain the sole networking stack, unchanged.

## Test / build result

This is a dotfiles/config-only repo with no test suite or build step. The change is a 2-line deletion of stale config; it cannot break anything that currently works.

---

🤖 AI-generated — review before merging.