### PR TITLE
fastfetch: use OS-autodetected logo on macOS instead of NixOS PNG (#58)

### DIFF
--- a/fastfetch/config-darwin.jsonc
+++ b/fastfetch/config-darwin.jsonc
@@ -1,0 +1,100 @@
+// fastfetch — Modus Vivendi rice (macOS)
+// Same as config.jsonc but with an OS-autodetected logo instead of the
+// NixOS-only kitty-direct PNG, so macOS hosts don't render a NixOS logo.
+// "auto" picks the host's own built-in logo and degrades gracefully to
+// ASCII outside of kitty/iTerm/sixel-capable terminals.
+{
+  "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
+  "logo": {
+    "type": "auto",
+    "padding": {
+      "top": 1,
+      "right": 3
+    }
+  },
+  "display": {
+    "separator": "  ",
+    "color": {
+      "keys": "38;2;47;175;255",
+      "title": "38;2;254;172;208",
+      "output": "38;2;255;255;255"
+    },
+    "key": {
+      "width": 1
+    }
+  },
+  "modules": [
+    {
+      "type": "title",
+      "color": {
+        "user": "38;2;254;172;208",
+        "at": "38;2;152;152;152",
+        "host": "38;2;121;168;255"
+      }
+    },
+    "separator",
+    {
+      "type": "os",
+      "key": "  ",
+      "keyColor": "38;2;47;175;255"
+    },
+    {
+      "type": "kernel",
+      "key": "  ",
+      "keyColor": "38;2;47;175;255"
+    },
+    {
+      "type": "uptime",
+      "key": "  ",
+      "keyColor": "38;2;254;196;63"
+    },
+    {
+      "type": "packages",
+      "key": "  ",
+      "keyColor": "38;2;68;188;68"
+    },
+    {
+      "type": "shell",
+      "key": "  ",
+      "keyColor": "38;2;68;188;68"
+    },
+    {
+      "type": "wm",
+      "key": "  ",
+      "keyColor": "38;2;182;160;255"
+    },
+    {
+      "type": "terminal",
+      "key": "  ",
+      "keyColor": "38;2;182;160;255"
+    },
+    {
+      "type": "cpu",
+      "key": "  ",
+      "keyColor": "38;2;255;95;89"
+    },
+    {
+      "type": "gpu",
+      "key": "  ",
+      "keyColor": "38;2;255;95;89"
+    },
+    {
+      "type": "memory",
+      "key": "  ",
+      "keyColor": "38;2;254;196;63"
+    },
+    {
+      "type": "disk",
+      "key": "  ",
+      "keyColor": "38;2;254;196;63",
+      "folders": "/"
+    },
+    "separator",
+    {
+      "type": "colors",
+      "symbol": "circle",
+      "paddingLeft": 0
+    },
+    "break"
+  ]
+}

--- a/home/common.nix
+++ b/home/common.nix
@@ -251,11 +251,20 @@
   };
 
   # ---------- Dotfiles that stay as plain config files ----------
-  # Symlinked into ~/.config so editing the repo is a live edit. These four
-  # are portable; Hyprland/waybar/rofi/dunst symlinks are added in
-  # home/ibuki.nix (Linux only).
+  # Symlinked into ~/.config so editing the repo is a live edit. These
+  # (fastfetch, nvim, kitty.conf, starship.toml) are portable;
+  # Hyprland/waybar/rofi/dunst symlinks are added in home/ibuki.nix
+  # (Linux only).
   xdg.configFile = {
-    "fastfetch".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/fastfetch";
+    # fastfetch/config.jsonc is platform-specific (the NixOS one hardcodes
+    # nixos-logo.png via kitty-direct, which is wrong branding on macOS), so
+    # it's symlinked per-file instead of the whole directory in one go.
+    "fastfetch/config.jsonc".source = config.lib.file.mkOutOfStoreSymlink (
+      "${config.home.homeDirectory}/dotfiles/fastfetch/"
+      + (if pkgs.stdenv.isDarwin then "config-darwin.jsonc" else "config.jsonc")
+    );
+    "fastfetch/nixos-logo.png".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/fastfetch/nixos-logo.png";
+    "fastfetch/nixos-logo.svg".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/fastfetch/nixos-logo.svg";
     "nvim".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/nvim";
     "kitty/kitty.conf".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/kitty/kitty.conf";
     "starship.toml".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/starship/starship.toml";


### PR DESCRIPTION
Closes #58

## What changed
`home/common.nix` symlinked the entire `fastfetch/` directory as one unit to both NixOS (`home/ibuki.nix`) and macOS (`home/darwin.nix`) hosts, so both got the same `config.jsonc` — which hardcodes a `kitty-direct` NixOS PNG logo (`fastfetch/nixos-logo.png`). On macOS this rendered a NixOS logo next to macOS system info, and only worked at all under kitty.

- Added `fastfetch/config-darwin.jsonc` — identical to `config.jsonc` except the `logo` block uses `"type": "auto"` with no hardcoded `source`, so fastfetch auto-detects the host OS logo and the best rendering protocol the terminal supports (no longer kitty-only).
- `home/common.nix` now symlinks `fastfetch/config.jsonc` per-file (instead of the whole directory) and picks `config-darwin.jsonc` on Darwin (`pkgs.stdenv.isDarwin`) vs. the original `config.jsonc` on NixOS, which is otherwise untouched. `nixos-logo.png`/`.svg` are still symlinked as before.

## Why
NixOS branding shown on a Mac is wrong, and the fix needed to be platform-aware without disturbing the existing NixOS rice, since `config.jsonc` is shared via symlink between both `home-manager` profiles.

## Test result
No Nix toolchain is available in this sandbox, so `nix-instantiate --parse` / `nixpkgs-fmt` / `statix` / `deadnix` couldn't be run (pre-existing environment limitation, not caused by this change). What I could verify:
- `bash tests/check.sh` — shell (`bash -n`, `shellcheck`) and JSON (`jq`) sections pass; Nix-tool sections skip/fail only because the binaries aren't installed here.
- `fastfetch/config-darwin.jsonc` validated as well-formed JSON after stripping `//` comments (`jq -e .`).
- `fastfetch/config.jsonc` is byte-for-byte unchanged (verified via `git diff`), satisfying "NixOS logo unchanged".

🤖 AI-generated — review before merging.